### PR TITLE
Phase 9: add v1 Feat schema + strict validator and CI (feats only)

### DIFF
--- a/.github/workflows/phase9-feats.yml
+++ b/.github/workflows/phase9-feats.yml
@@ -1,0 +1,40 @@
+﻿name: Phase 9 — Feats (strict)
+
+on:
+  pull_request:
+    branches: [ master ]
+    paths:
+      - "schema/2024/v1/rules.feat.schema.json"
+      - "scripts/validate_phase9_feats.py"
+      - "rules/2024/feat.json"
+      - ".github/workflows/phase9-feats.yml"
+  push:
+    branches-ignore: [ master ]
+    paths:
+      - "schema/2024/v1/rules.feat.schema.json"
+      - "scripts/validate_phase9_feats.py"
+      - "rules/2024/feat.json"
+      - ".github/workflows/phase9-feats.yml"
+  workflow_dispatch:
+
+jobs:
+  validate-feats:
+    name: Validate feats (Phase 9 strict)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: |
+          python -VV
+          python -m pip install --upgrade pip jsonschema
+
+      - name: Run strict validator
+        run: |
+          python scripts/validate_phase9_feats.py --file rules/2024/feat.json --schema schema/2024/v1/rules.feat.schema.json

--- a/schema/2024/v1/rules.feat.schema.json
+++ b/schema/2024/v1/rules.feat.schema.json
@@ -1,0 +1,40 @@
+﻿{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schema/2024/v1/rules.feat.schema.json",
+  "title": "One D&D 2024 — Feat (v1)",
+  "description": "Minimal v1 schema for 2024 feats. Conservative: enforce key types that matter; allow additional properties. Sources must be 2024 X* books.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": true,
+    "required": ["name", "source"],
+    "properties": {
+      "name": { "type": "string", "minLength": 1 },
+      "source": { "type": "string", "pattern": "^X[A-Z]+$" },
+      "page":  { "type": ["integer", "string"] },
+      "entries": {
+        "anyOf": [
+          { "type": "string" },
+          { "type": "array" },
+          { "type": "object" }
+        ]
+      },
+      "prerequisite": {
+        "anyOf": [
+          { "type": "string" },
+          { "type": "array" },
+          { "type": "object" },
+          { "type": "null" }
+        ]
+      },
+      "prerequisites": {
+        "anyOf": [
+          { "type": "string" },
+          { "type": "array" },
+          { "type": "object" },
+          { "type": "null" }
+        ]
+      }
+    }
+  }
+}

--- a/scripts/validate_phase9_feats.py
+++ b/scripts/validate_phase9_feats.py
@@ -1,0 +1,56 @@
+﻿import argparse, json, sys
+from pathlib import Path
+from jsonschema import Draft202012Validator, exceptions as js_exc
+
+DEF_DATA = Path("rules/2024/feat.json")
+DEF_SCHEMA = Path("schema/2024/v1/rules.feat.schema.json")
+
+def load_json(p: Path):
+    try:
+        with p.open("r", encoding="utf-8-sig") as fh:
+            return json.load(fh)
+    except FileNotFoundError:
+        print(f"❌ File not found: {p}", file=sys.stderr); sys.exit(2)
+    except json.JSONDecodeError as e:
+        print(f"❌ JSON parse error in {p}: {e}", file=sys.stderr); sys.exit(2)
+
+def main():
+    ap = argparse.ArgumentParser(description="Phase 9 strict validator (feats)")
+    ap.add_argument("--file", default=str(DEF_DATA), help="Path to feat.json")
+    ap.add_argument("--schema", default=str(DEF_SCHEMA), help="Path to feat schema")
+    args = ap.parse_args()
+
+    data = load_json(Path(args.file))
+    # Accept either a root array or an object containing a 'feat' array.
+    if isinstance(data, dict):
+        if "feat" in data and isinstance(data["feat"], list):
+            data_to_validate = data["feat"]
+        else:
+            print("❌ Expected key 'feat' with a list value in the root object.", file=sys.stderr)
+            sys.exit(1)
+    elif isinstance(data, list):
+        data_to_validate = data
+    else:
+        print("❌ Unexpected root type in feat.json; expected array or object.", file=sys.stderr)
+        sys.exit(1)
+
+    schema = load_json(Path(args.schema))
+    try:
+        validator = Draft202012Validator(schema)
+    except js_exc.SchemaError as e:
+        print(f"❌ Schema error: {e}", file=sys.stderr); sys.exit(2)
+
+    errors = sorted(validator.iter_errors(data_to_validate), key=lambda e: e.path)
+    if errors:
+        print(f"❌ Phase 9 (feats) schema violations: {len(errors)}")
+        for i, err in enumerate(errors[:25], 1):
+            loc = "$" + "".join([f"[{repr(p)}]" if isinstance(p, int) else f".{p}" for p in err.path])
+            print(f"  {i:02d}. {loc}: {err.message}")
+        if len(errors) > 25:
+            print(f"  ...and {len(errors)-25} more")
+        sys.exit(1)
+
+    print("✅ Phase 9: feats validated cleanly (rules/2024/feat.json)")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Phase 9 — Feats: add v1 schema, strict validator, and CI

**What**
- Add `schema/2024/v1/rules.feat.schema.json` (conservative v1: require `name` + `source`; permissive types; UTF-8 BOM tolerant readers).
- Add strict local validator `scripts/validate_phase9_feats.py`.
- Add CI workflow `.github/workflows/phase9-feats.yml` that fails the build on Feats violations only.
- All other validations remain warn-only.

**Why**
- Phase 9 of the implementation plan expands strict coverage category-by-category, starting with Feats, while keeping the rest warn-only.

**How to test locally**
```powershell
python .\scripts\validate_phase9_feats.py --file .\rules\2024\feat.json --schema .\schema\2024\v1\rules.feat.schema.json