### PR TITLE
Phase 9: add v1 Monster schema + strict validator and CI (monsters only)

### DIFF
--- a/.github/workflows/phase9-monsters.yml
+++ b/.github/workflows/phase9-monsters.yml
@@ -1,0 +1,37 @@
+﻿name: Phase 9 - Monsters (strict)
+
+on:
+  pull_request:
+    branches: [ master ]
+    paths:
+      - "schema/2024/v1/rules.monster.schema.json"
+      - "scripts/validate_phase9_monsters.py"
+      - "rules/2024/monster.json"
+      - ".github/workflows/phase9-monsters.yml"
+  push:
+    branches-ignore: [ master ]
+    paths:
+      - "schema/2024/v1/rules.monster.schema.json"
+      - "scripts/validate_phase9_monsters.py"
+      - "rules/2024/monster.json"
+      - ".github/workflows/phase9-monsters.yml"
+  workflow_dispatch:
+
+jobs:
+  validate-monsters:
+    name: Validate monsters (Phase 9 strict)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -VV
+          python -m pip install --upgrade pip jsonschema
+      - name: Run strict validator
+        run: |
+          python scripts/validate_phase9_monsters.py --file rules/2024/monster.json --schema schema/2024/v1/rules.monster.schema.json

--- a/schema/2024/v1/rules.monster.schema.json
+++ b/schema/2024/v1/rules.monster.schema.json
@@ -1,0 +1,33 @@
+﻿{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schema/2024/v1/rules.monster.schema.json",
+  "title": "One D&D 2024 — Monster (v1, conservative)",
+  "description": "Minimal v1 schema for 2024 monsters. Enforce only key identifiers; be permissive on shape to avoid over-specifying. Keep other categories warn-only.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": true,
+    "required": ["name", "source"],
+    "properties": {
+      "name":   { "type": "string", "minLength": 1 },
+      "source": { "type": "string", "pattern": "^X[A-Z]+$" },
+      "page":   { "type": ["integer", "string"] },
+
+      "cr":     { "type": ["number", "string", "object"] },
+      "type":   { "type": ["string", "object"] },
+      "size":   { "type": ["string", "array"] },
+      "alignment": { "type": ["string", "array", "object"] },
+
+      "ac":     { "type": ["integer", "string", "array", "object"] },
+      "hp":     { "type": ["integer", "string", "object"] },
+      "speed":  { "type": ["string", "object"] },
+
+      "entries": { "type": ["string", "array", "object"] },
+      "actions": { "type": ["string", "array", "object"] },
+      "reactions": { "type": ["string", "array", "object"] },
+      "legendary": { "type": ["string", "array", "object"] },
+
+      "traits": { "type": ["string", "array", "object"] }
+    }
+  }
+}

--- a/scripts/validate_phase9_monsters.py
+++ b/scripts/validate_phase9_monsters.py
@@ -1,0 +1,55 @@
+﻿import argparse, json, sys
+from pathlib import Path
+from jsonschema import Draft202012Validator, exceptions as js_exc
+
+DEF_DATA = Path("rules/2024/monster.json")
+DEF_SCHEMA = Path("schema/2024/v1/rules.monster.schema.json")
+
+def load_json(p: Path):
+    try:
+        with p.open("r", encoding="utf-8-sig") as fh:
+            return json.load(fh)
+    except FileNotFoundError:
+        print(f"❌ File not found: {p}", file=sys.stderr); sys.exit(2)
+    except json.JSONDecodeError as e:
+        print(f"❌ JSON parse error in {p}: {e}", file=sys.stderr); sys.exit(2)
+
+def main():
+    ap = argparse.ArgumentParser(description="Phase 9 strict validator (monsters)")
+    ap.add_argument("--file", default=str(DEF_DATA), help="Path to monster.json")
+    ap.add_argument("--schema", default=str(DEF_SCHEMA), help="Path to monster schema")
+    args = ap.parse_args()
+
+    data = load_json(Path(args.file))
+    if isinstance(data, dict):
+        if "monster" in data and isinstance(data["monster"], list):
+            data_to_validate = data["monster"]
+        else:
+            print("❌ Expected key 'monster' with a list value in the root object.", file=sys.stderr)
+            sys.exit(1)
+    elif isinstance(data, list):
+        data_to_validate = data
+    else:
+        print("❌ Unexpected root type in monster.json; expected array or object.", file=sys.stderr)
+        sys.exit(1)
+
+    schema = load_json(Path(args.schema))
+    try:
+        validator = Draft202012Validator(schema)
+    except js_exc.SchemaError as e:
+        print(f"❌ Schema error: {e}", file=sys.stderr); sys.exit(2)
+
+    errors = sorted(validator.iter_errors(data_to_validate), key=lambda e: e.path)
+    if errors:
+        print(f"❌ Phase 9 (monsters) schema violations: {len(errors)}")
+        for i, err in enumerate(errors[:25], 1):
+            loc = "$" + "".join([f"[{repr(p)}]" if isinstance(p, int) else f".{p}" for p in err.path])
+            print(f"  {i:02d}. {loc}: {err.message}")
+        if len(errors) > 25:
+            print(f"  ...and {len(errors)-25} more")
+        sys.exit(1)
+
+    print("✅ Phase 9: monsters validated cleanly (rules/2024/monster.json)")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Phase 9 — Monsters: v1 schema, strict validator & CI

### Summary
Implements **Phase 9** for Monsters: adds a conservative **v1 Monster schema**, a **strict local validator**, and a **dedicated CI workflow** that fails on Monster violations only. All other categories remain warn-only per the plan (Phase 9 extends strict coverage category-by-category).

### What’s included
- **Schema**: `schema/2024/v1/rules.monster.schema.json`
  - Minimal + conservative: requires only `name` (string) and `source` (`^X[A-Z]+$`), permits additional properties.
  - Key fields typed but permissive (`cr`, `type`, `size`, `alignment`, `ac`, `hp`, `speed`, `entries`, `actions`, `reactions`, `legendary`, `traits` allow common 5etools shapes).
- **Validator**: `scripts/validate_phase9_monsters.py`
  - BOM-tolerant reads (`utf-8-sig`).
  - Accepts either root array or `{ "monster": [...] }`.
  - Prints a clear ✅ / ❌ summary and lists first 25 errors.
- **CI**: `.github/workflows/phase9-monsters.yml`
  - Runs on PRs touching the monster schema, validator, data file, or the workflow itself.
  - Fails the build on schema violations for Monsters only; other categories remain warn-only.

### Why
Aligns with **Phase 9** of `schema_implementation_plan.docx`: add strict validation incrementally (feats → monsters → others), keep scope conservative, and avoid over-specifying fields until we have certainty.

### How to test locally
```powershell
python .\scripts\validate_phase9_monsters.py --file .\rules\2024\monster.json --schema .\schema\2024\v1\rules.monster.schema.json
