### PR TITLE
Phase 9: add v1 Background schema + strict validator and CI (backgrou…

### DIFF
--- a/.github/workflows/phase9-backgrounds.yml
+++ b/.github/workflows/phase9-backgrounds.yml
@@ -1,0 +1,37 @@
+﻿name: Phase 9 - Backgrounds (strict)
+
+on:
+  pull_request:
+    branches: [ master ]
+    paths:
+      - "schema/2024/v1/rules.background.schema.json"
+      - "scripts/validate_phase9_backgrounds.py"
+      - "rules/2024/background.json"
+      - ".github/workflows/phase9-backgrounds.yml"
+  push:
+    branches-ignore: [ master ]
+    paths:
+      - "schema/2024/v1/rules.background.schema.json"
+      - "scripts/validate_phase9_backgrounds.py"
+      - "rules/2024/background.json"
+      - ".github/workflows/phase9-backgrounds.yml"
+  workflow_dispatch:
+
+jobs:
+  validate-backgrounds:
+    name: Validate backgrounds (Phase 9 strict)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -VV
+          python -m pip install --upgrade pip jsonschema
+      - name: Run strict validator
+        run: |
+          python scripts/validate_phase9_backgrounds.py --file rules/2024/background.json --schema schema/2024/v1/rules.background.schema.json

--- a/schema/2024/v1/rules.background.schema.json
+++ b/schema/2024/v1/rules.background.schema.json
@@ -1,0 +1,25 @@
+﻿{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schema/2024/v1/rules.background.schema.json",
+  "title": "One D&D 2024 — Background (v1, conservative)",
+  "description": "Minimal v1 schema for 2024 backgrounds. Require only identifiers; keep other fields permissive to avoid over-specifying.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": true,
+    "required": ["name", "source"],
+    "properties": {
+      "name":   { "type": "string", "minLength": 1 },
+      "source": { "type": "string", "pattern": "^X[A-Z]+$" },
+      "page":   { "type": ["integer", "string"] },
+
+      "entries":            { "type": ["string", "array", "object"] },
+      "skillProficiencies": { "type": ["string", "array", "object"] },
+      "toolProficiencies":  { "type": ["string", "array", "object"] },
+      "languages":          { "type": ["string", "array", "object"] },
+      "feat":               { "type": ["string", "array", "object"] },
+      "startingEquipment":  { "type": ["string", "array", "object"] },
+      "features":           { "type": ["string", "array", "object"] }
+    }
+  }
+}

--- a/scripts/validate_phase9_backgrounds.py
+++ b/scripts/validate_phase9_backgrounds.py
@@ -1,0 +1,53 @@
+﻿import argparse, json, sys
+from pathlib import Path
+from jsonschema import Draft202012Validator, exceptions as js_exc
+
+DEF_DATA = Path("rules/2024/background.json")
+DEF_SCHEMA = Path("schema/2024/v1/rules.background.schema.json")
+
+def load_json(p: Path):
+    try:
+        with p.open("r", encoding="utf-8-sig") as fh:
+            return json.load(fh)
+    except FileNotFoundError:
+        print(f"❌ File not found: {p}", file=sys.stderr); sys.exit(2)
+    except json.JSONDecodeError as e:
+        print(f"❌ JSON parse error in {p}: {e}", file=sys.stderr); sys.exit(2)
+
+def extract_array(data):
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        for k in ("background", "backgrounds"):
+            if k in data and isinstance(data[k], list):
+                return data[k]
+    print("❌ Expected a root array or an object with 'background'/'backgrounds' list.", file=sys.stderr)
+    sys.exit(1)
+
+def main():
+    ap = argparse.ArgumentParser(description="Phase 9 strict validator (backgrounds)")
+    ap.add_argument("--file", default=str(DEF_DATA), help="Path to background.json")
+    ap.add_argument("--schema", default=str(DEF_SCHEMA), help="Path to background schema")
+    args = ap.parse_args()
+
+    data = extract_array(load_json(Path(args.file)))
+    schema = load_json(Path(args.schema))
+    try:
+        validator = Draft202012Validator(schema)
+    except js_exc.SchemaError as e:
+        print(f"❌ Schema error: {e}", file=sys.stderr); sys.exit(2)
+
+    errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
+    if errors:
+        print(f"❌ Phase 9 (backgrounds) schema violations: {len(errors)}")
+        for i, err in enumerate(errors[:25], 1):
+            loc = "$" + "".join([f"[{repr(p)}]" if isinstance(p, int) else f".{p}" for p in err.path])
+            print(f"  {i:02d}. {loc}: {err.message}")
+        if len(errors) > 25:
+            print(f"  ...and {len(errors)-25} more")
+        sys.exit(1)
+
+    print("✅ Phase 9: backgrounds validated cleanly (rules/2024/background.json)")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Phase 9 — Backgrounds: v1 schema, strict validator & CI

### Summary
Extends Phase 9 to **Backgrounds** with a conservative v1 schema, a strict local validator, and a dedicated CI job that fails on Background violations only. Other categories remain warn-only per the plan.

### What’s included
- **Schema**: `schema/2024/v1/rules.background.schema.json` (require `name`, `source` matching X*; permissive for other common fields).
- **Validator**: `scripts/validate_phase9_backgrounds.py` (BOM-tolerant; accepts root array or `{ "background"/"backgrounds": [...] }`).
- **CI**: `.github/workflows/phase9-backgrounds.yml` (fails build on Background violations only).

### Why
Per Phase 9: extend strict coverage category-by-category with separate CI that fails only for the new target; keep others warn-only. (See `schema_implementation_plan.docx`, Phase 9.) 

