### PR TITLE
Phase 9: add v1 Language schema + strict validator and CI (languages …

### DIFF
--- a/.github/workflows/phase9-languages.yml
+++ b/.github/workflows/phase9-languages.yml
@@ -1,0 +1,37 @@
+﻿name: Phase 9 - Languages (strict)
+
+on:
+  pull_request:
+    branches: [ master ]
+    paths:
+      - "schema/2024/v1/rules.language.schema.json"
+      - "scripts/validate_phase9_languages.py"
+      - "rules/2024/language.json"
+      - ".github/workflows/phase9-languages.yml"
+  push:
+    branches-ignore: [ master ]
+    paths:
+      - "schema/2024/v1/rules.language.schema.json"
+      - "scripts/validate_phase9_languages.py"
+      - "rules/2024/language.json"
+      - ".github/workflows/phase9-languages.yml"
+  workflow_dispatch:
+
+jobs:
+  validate-languages:
+    name: Validate languages (Phase 9 strict)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -VV
+          python -m pip install --upgrade pip jsonschema
+      - name: Run strict validator
+        run: |
+          python scripts/validate_phase9_languages.py --file rules/2024/language.json --schema schema/2024/v1/rules.language.schema.json

--- a/schema/2024/v1/rules.language.schema.json
+++ b/schema/2024/v1/rules.language.schema.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schema/2024/v1/rules.language.schema.json",
+  "title": "One D&D 2024 — Language (v1, conservative)",
+  "description": "Minimal v1 schema for 2024 languages. Require identifiers; keep other fields permissive. Source limited to X* books.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": true,
+    "required": ["name", "source"],
+    "properties": {
+      "name":   { "type": "string", "minLength": 1 },
+      "source": { "type": "string", "pattern": "^X[A-Z]+$" },
+      "page":   { "type": ["integer", "string"] },
+
+      "typicalSpeakers": { "type": ["string", "array"] },
+      "script":          { "type": ["string", "null"] },
+      "rarity":          { "type": ["string", "null"] },
+      "entries":         { "type": ["string", "array", "object"] },
+      "dialects":        { "type": ["array", "string", "object"] }
+    }
+  }
+}

--- a/scripts/validate_phase9_languages.py
+++ b/scripts/validate_phase9_languages.py
@@ -1,0 +1,53 @@
+﻿import argparse, json, sys
+from pathlib import Path
+from jsonschema import Draft202012Validator, exceptions as js_exc
+
+DEF_DATA = Path("rules/2024/language.json")
+DEF_SCHEMA = Path("schema/2024/v1/rules.language.schema.json")
+
+def load_json(p: Path):
+    try:
+        with p.open("r", encoding="utf-8-sig") as fh:
+            return json.load(fh)
+    except FileNotFoundError:
+        print(f"❌ File not found: {p}", file=sys.stderr); sys.exit(2)
+    except json.JSONDecodeError as e:
+        print(f"❌ JSON parse error in {p}: {e}", file=sys.stderr); sys.exit(2)
+
+def extract_array(data):
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        for k in ("language", "languages"):
+            if k in data and isinstance(data[k], list):
+                return data[k]
+    print("❌ Expected a root array or an object with 'language'/'languages' list.", file=sys.stderr)
+    sys.exit(1)
+
+def main():
+    ap = argparse.ArgumentParser(description="Phase 9 strict validator (languages)")
+    ap.add_argument("--file", default=str(DEF_DATA), help="Path to language.json")
+    ap.add_argument("--schema", default=str(DEF_SCHEMA), help="Path to language schema")
+    args = ap.parse_args()
+
+    data = extract_array(load_json(Path(args.file)))
+    schema = load_json(Path(args.schema))
+    try:
+        validator = Draft202012Validator(schema)
+    except js_exc.SchemaError as e:
+        print(f"❌ Schema error: {e}", file=sys.stderr); sys.exit(2)
+
+    errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
+    if errors:
+        print(f"❌ Phase 9 (languages) schema violations: {len(errors)}")
+        for i, err in enumerate(errors[:25], 1):
+            loc = "$" + "".join([f"[{repr(p)}]" if isinstance(p, int) else f".{p}" for p in err.path])
+            print(f"  {i:02d}. {loc}: {err.message}")
+        if len(errors) > 25:
+            print(f"  ...and {len(errors)-25} more")
+        sys.exit(1)
+
+    print("✅ Phase 9: languages validated cleanly (rules/2024/language.json)")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Phase 9 — Languages: v1 schema, strict validator & CI

Extends Phase 9 to **Languages** with a conservative v1 schema, a strict local validator, and a dedicated CI workflow that fails on Language violations only. Other categories remain warn-only per the plan (Phase 9 = extend gradually category-by-category). See `schema_implementation_plan.docx` Phase 9. 

- Schema: `schema/2024/v1/rules.language.schema.json` (require `name`, `source` /^X[A-Z]+$/; permissive for other fields).
- Validator: `scripts/validate_phase9_languages.py` (BOM-tolerant; accepts root array or `{ "language"/"languages": [...] }`).
- CI: `.github/workflows/phase9-languages.yml` (red build on Language violations only).

Local check:
```powershell
python .\scripts\validate_phase9_languages.py --file .\rules\2024\language.json --schema .\schema\2024\v1\rules.language.schema.json
