### PR TITLE
Phase 9: add v1 Condition schema + strict validator and CI (condition…

### DIFF
--- a/.github/workflows/phase9-conditions.yml
+++ b/.github/workflows/phase9-conditions.yml
@@ -1,0 +1,37 @@
+﻿name: Phase 9 - Conditions (strict)
+
+on:
+  pull_request:
+    branches: [ master ]
+    paths:
+      - "schema/2024/v1/rules.condition.schema.json"
+      - "scripts/validate_phase9_conditions.py"
+      - "rules/2024/condition.json"
+      - ".github/workflows/phase9-conditions.yml"
+  push:
+    branches-ignore: [ master ]
+    paths:
+      - "schema/2024/v1/rules.condition.schema.json"
+      - "scripts/validate_phase9_conditions.py"
+      - "rules/2024/condition.json"
+      - ".github/workflows/phase9-conditions.yml"
+  workflow_dispatch:
+
+jobs:
+  validate-conditions:
+    name: Validate conditions (Phase 9 strict)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -VV
+          python -m pip install --upgrade pip jsonschema
+      - name: Run strict validator
+        run: |
+          python scripts/validate_phase9_conditions.py --file rules/2024/condition.json --schema schema/2024/v1/rules.condition.schema.json

--- a/schema/2024/v1/rules.condition.schema.json
+++ b/schema/2024/v1/rules.condition.schema.json
@@ -1,0 +1,16 @@
+﻿{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "One D&D 2024 — Condition (v1, conservative)",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": true,
+    "required": ["name", "source"],
+    "properties": {
+      "name":   { "type": "string", "minLength": 1 },
+      "source": { "type": "string", "pattern": "^X[A-Z]+$" },
+      "page":   { "type": ["integer", "string", "null"] },
+      "entries": { "type": ["string", "array", "object"] }
+    }
+  }
+}

--- a/scripts/validate_phase9_conditions.py
+++ b/scripts/validate_phase9_conditions.py
@@ -1,0 +1,41 @@
+﻿import argparse, json, sys
+from pathlib import Path
+from jsonschema import Draft202012Validator, exceptions as js_exc
+
+DEF_DATA = Path("rules/2024/condition.json")
+DEF_SCHEMA = Path("schema/2024/v1/rules.condition.schema.json")
+
+def load_json(p: Path):
+    with p.open("r", encoding="utf-8-sig") as fh:
+        return json.load(fh)
+
+def extract_array(data):
+    if isinstance(data, list): return data
+    if isinstance(data, dict):
+        for k in ("condition","conditions"):
+            if k in data and isinstance(data[k], list): return data[k]
+    print("❌ Expected a root array or an object with 'condition'/'conditions' list.", file=sys.stderr); sys.exit(1)
+
+def main():
+    ap = argparse.ArgumentParser(description="Phase 9 strict validator (conditions)")
+    ap.add_argument("--file", default=str(DEF_DATA))
+    ap.add_argument("--schema", default=str(DEF_SCHEMA))
+    args = ap.parse_args()
+
+    data = extract_array(load_json(Path(args.file)))
+    schema = load_json(Path(args.schema))
+    validator = Draft202012Validator(schema)
+
+    errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
+    if errors:
+        print(f"❌ Phase 9 (conditions) schema violations: {len(errors)}")
+        for i, err in enumerate(errors[:25], 1):
+            loc = "$" + "".join([f"[{repr(p)}]" if isinstance(p, int) else f".{p}" for p in err.path])
+            print(f"  {i:02d}. {loc}: {err.message}")
+        if len(errors) > 25: print(f"  ...and {len(errors)-25} more")
+        sys.exit(1)
+    print("[OK] Phase 9: conditions validated cleanly (rules/2024/condition.json)")
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
Phase 9 — Conditions: v1 schema, strict validator & CI

Extends Phase 9 to Conditions with a conservative v1 schema, a strict local validator, and a dedicated CI job that fails on Condition violations only. Other categories remain warn-only per the plan (Phase 9 = extend gradually category-by-category). See schema_implementation_plan.docx, Phase 9.

Schema: schema/2024/v1/rules.condition.schema.json (require name, source /^X[A-Z]+$/; permissive entries).

Validator: scripts/validate_phase9_conditions.py (BOM-tolerant; accepts root array or { "condition"/"conditions": [...] }).

CI: .github/workflows/phase9-conditions.yml (red build on Conditions violations only).

python .\scripts\validate_phase9_conditions.py --file .\rules\2024\condition.json --schema .\schema\2024\v1\rules.condition.schema.json
