### PR TITLE
Phase 9: shared validation helper + v1 Skills schema, strict validato…

### DIFF
--- a/.github/workflows/phase9-skills.yml
+++ b/.github/workflows/phase9-skills.yml
@@ -1,0 +1,41 @@
+﻿name: Phase 9 - Skills (strict)
+
+on:
+  pull_request:
+    branches: [ master ]
+    paths:
+      - "schema/2024/v1/rules.skill.schema.json"
+      - "scripts/validate_phase9_skills.py"
+      - "scripts/_validation_common.py"
+      - "scripts/__init__.py"
+      - "rules/2024/skill.json"
+      - ".github/workflows/phase9-skills.yml"
+  push:
+    branches-ignore: [ master ]
+    paths:
+      - "schema/2024/v1/rules.skill.schema.json"
+      - "scripts/validate_phase9_skills.py"
+      - "scripts/_validation_common.py"
+      - "scripts/__init__.py"
+      - "rules/2024/skill.json"
+      - ".github/workflows/phase9-skills.yml"
+  workflow_dispatch:
+
+jobs:
+  validate-skills:
+    name: Validate skills (Phase 9 strict)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -VV
+          python -m pip install --upgrade pip jsonschema
+      - name: Run strict validator (module mode)
+        run: |
+          python -m scripts.validate_phase9_skills

--- a/schema/2024/v1/rules.skill.schema.json
+++ b/schema/2024/v1/rules.skill.schema.json
@@ -1,0 +1,18 @@
+﻿{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "One D&D 2024 — Skill (v1, conservative)",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": true,
+    "required": ["name", "source"],
+    "properties": {
+      "name":   { "type": "string", "minLength": 1 },
+      "source": { "type": "string", "pattern": "^X[A-Z]+$" },
+      "page":   { "type": ["integer", "string", "null"] },
+
+      "ability": { "type": ["string", "null"] },
+      "entries": { "type": ["string", "array", "object"] }
+    }
+  }
+}

--- a/scripts/_validation_common.py
+++ b/scripts/_validation_common.py
@@ -1,0 +1,50 @@
+﻿import json, sys
+from pathlib import Path
+from jsonschema import Draft202012Validator, exceptions as js_exc
+
+def load_json(path):
+    with Path(path).open("r", encoding="utf-8-sig") as fh:
+        return json.load(fh)
+
+def extract_array(data, array_keys):
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        for k in (array_keys or []):
+            if k in data and isinstance(data[k], list):
+                return data[k]
+    print("ERROR: Expected a root array or an object with one of keys: " + ", ".join(array_keys), flush=True, file=sys.stderr)
+    return None
+
+def run_standard_validation(category, data_path, schema_path, array_keys):
+    try:
+        raw = load_json(data_path)
+    except FileNotFoundError:
+        print(f"ERROR: File not found: {data_path}", flush=True, file=sys.stderr); return 2
+    except json.JSONDecodeError as e:
+        print(f"ERROR: JSON parse error in {data_path}: {e}", flush=True, file=sys.stderr); return 2
+
+    data = extract_array(raw, array_keys)
+    if data is None:
+        return 1
+
+    try:
+        schema = load_json(schema_path)
+        validator = Draft202012Validator(schema)
+    except js_exc.SchemaError as e:
+        print(f"ERROR: Schema error: {e}", flush=True, file=sys.stderr); return 2
+    except Exception as e:
+        print(f"ERROR: Schema load error: {e}", flush=True, file=sys.stderr); return 2
+
+    errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
+    if errors:
+        print(f"ERROR: Phase 9 ({category}) schema violations: {len(errors)}", flush=True)
+        for i, err in enumerate(errors[:25], 1):
+            loc = "$" + "".join([f"[{repr(p)}]" if isinstance(p, int) else f".{p}" for p in err.path])
+            print(f"  {i:02d}. {loc}: {err.message}", flush=True)
+        if len(errors) > 25:
+            print(f"  ...and {len(errors)-25} more", flush=True)
+        return 1
+
+    print(f"[OK] Phase 9: {category} validated cleanly ({data_path})", flush=True)
+    return 0

--- a/scripts/validate_phase9_skills.py
+++ b/scripts/validate_phase9_skills.py
@@ -1,0 +1,10 @@
+﻿import sys
+from scripts._validation_common import run_standard_validation
+
+if __name__ == "__main__":
+    sys.exit(run_standard_validation(
+        category="skills",
+        data_path="rules/2024/skill.json",
+        schema_path="schema/2024/v1/rules.skill.schema.json",
+        array_keys=["skill", "skills"]
+    ))


### PR DESCRIPTION
## Phase 9 — Skills: v1 schema, strict validator & CI (+ shared helper)

Implements Phase 9 for **Skills** and introduces a shared `_validation_common.py` so all validators:
- print ASCII-only messages with flush (no emoji/encoding issues),
- tolerate UTF-8 BOM,
- accept root array or common 5etools root keys,
- and return clear non-zero exit codes on failure.

CI runs validators in **module mode** (`python -m scripts.validate_phase9_<cat>`) so imports work reliably. Other categories remain warn-only per the plan (`schema_implementation_plan.docx`, Phase 9).
