### PR TITLE
Phase 9: add v1 Sense schema + strict validator and CI (senses only)

### DIFF
--- a/.github/workflows/phase9-senses.yml
+++ b/.github/workflows/phase9-senses.yml
@@ -1,0 +1,41 @@
+﻿name: Phase 9 - Senses (strict)
+
+on:
+  pull_request:
+    branches: [ master ]
+    paths:
+      - "schema/2024/v1/rules.sense.schema.json"
+      - "scripts/validate_phase9_senses.py"
+      - "scripts/_validation_common.py"
+      - "scripts/__init__.py"
+      - "rules/2024/sense.json"
+      - ".github/workflows/phase9-senses.yml"
+  push:
+    branches-ignore: [ master ]
+    paths:
+      - "schema/2024/v1/rules.sense.schema.json"
+      - "scripts/validate_phase9_senses.py"
+      - "scripts/_validation_common.py"
+      - "scripts/__init__.py"
+      - "rules/2024/sense.json"
+      - ".github/workflows/phase9-senses.yml"
+  workflow_dispatch:
+
+jobs:
+  validate-senses:
+    name: Validate senses (Phase 9 strict)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -VV
+          python -m pip install --upgrade pip jsonschema
+      - name: Run strict validator (module mode)
+        run: |
+          python -m scripts.validate_phase9_senses

--- a/schema/2024/v1/rules.sense.schema.json
+++ b/schema/2024/v1/rules.sense.schema.json
@@ -1,0 +1,16 @@
+﻿{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "One D&D 2024 — Sense (v1, conservative)",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": true,
+    "required": ["name", "source"],
+    "properties": {
+      "name":   { "type": "string", "minLength": 1 },
+      "source": { "type": "string", "pattern": "^X[A-Z]+$" },
+      "page":   { "type": ["integer", "string", "null"] },
+      "entries": { "type": ["string", "array", "object"] }
+    }
+  }
+}

--- a/scripts/validate_phase9_senses.py
+++ b/scripts/validate_phase9_senses.py
@@ -1,0 +1,10 @@
+﻿import sys
+from scripts._validation_common import run_standard_validation
+
+if __name__ == "__main__":
+    sys.exit(run_standard_validation(
+        category="senses",
+        data_path="rules/2024/sense.json",
+        schema_path="schema/2024/v1/rules.sense.schema.json",
+        array_keys=["sense", "senses"]
+    ))


### PR DESCRIPTION
## Phase 9 — Senses: v1 schema, strict validator & CI

Extends Phase 9 to **Senses** with a conservative v1 schema, a strict validator (module mode, using `_validation_common.py`), and a dedicated CI workflow that fails on Senses violations only. Other categories remain warn-only per the plan (Phase 9 = extend gradually, one category at a time). See `schema_implementation_plan.docx`, Phase 9. :contentReference[oaicite:0]{index=0}

- **Schema**: `schema/2024/v1/rules.sense.schema.json` (require `name`, `source` /^X[A-Z]+$/; permissive `entries`).
- **Validator**: `scripts/validate_phase9_senses.py` (BOM-tolerant; accepts root array or `{ "sense"/"senses": [...] }`; ASCII/flush output via shared helper).
- **CI**: `.github/workflows/phase9-senses.yml` (runs `python -m scripts.validate_phase9_senses`; red build on Senses violations only).

**Local check**
```powershell
python -m scripts.validate_phase9_senses
