### PR TITLE
Phase 9: add v1 Action schema + strict validator and CI (actions only)

### DIFF
--- a/.github/workflows/phase9-actions.yml
+++ b/.github/workflows/phase9-actions.yml
@@ -1,0 +1,41 @@
+﻿name: Phase 9 - Actions (strict)
+
+on:
+  pull_request:
+    branches: [ master ]
+    paths:
+      - "schema/2024/v1/rules.action.schema.json"
+      - "scripts/validate_phase9_actions.py"
+      - "scripts/_validation_common.py"
+      - "scripts/__init__.py"
+      - "rules/2024/action.json"
+      - ".github/workflows/phase9-actions.yml"
+  push:
+    branches-ignore: [ master ]
+    paths:
+      - "schema/2024/v1/rules.action.schema.json"
+      - "scripts/validate_phase9_actions.py"
+      - "scripts/_validation_common.py"
+      - "scripts/__init__.py"
+      - "rules/2024/action.json"
+      - ".github/workflows/phase9-actions.yml"
+  workflow_dispatch:
+
+jobs:
+  validate-actions:
+    name: Validate actions (Phase 9 strict)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -VV
+          python -m pip install --upgrade pip jsonschema
+      - name: Run strict validator (module mode)
+        run: |
+          python -m scripts.validate_phase9_actions

--- a/schema/2024/v1/rules.action.schema.json
+++ b/schema/2024/v1/rules.action.schema.json
@@ -1,0 +1,16 @@
+﻿{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "One D&D 2024 — Action (v1, conservative)",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": true,
+    "required": ["name", "source"],
+    "properties": {
+      "name":   { "type": "string", "minLength": 1 },
+      "source": { "type": "string", "pattern": "^X[A-Z]+$" },
+      "page":   { "type": ["integer", "string", "null"] },
+      "entries": { "type": ["string", "array", "object"] }
+    }
+  }
+}

--- a/scripts/validate_phase9_actions.py
+++ b/scripts/validate_phase9_actions.py
@@ -1,0 +1,10 @@
+﻿import sys
+from scripts._validation_common import run_standard_validation
+
+if __name__ == "__main__":
+    sys.exit(run_standard_validation(
+        category="actions",
+        data_path="rules/2024/action.json",
+        schema_path="schema/2024/v1/rules.action.schema.json",
+        array_keys=["action", "actions"]
+    ))


### PR DESCRIPTION
Phase 9 — Actions: v1 schema, strict validator & CI

Extends Phase 9 to Actions with a conservative v1 schema, a strict validator (module mode, using _validation_common.py), and a dedicated CI workflow that fails on Actions violations only. Other categories remain warn-only per the plan (Phase 9 = extend gradually, one category at a time; see schema_implementation_plan.docx).

Local Check:
python -m scripts.validate_phase9_actions
