### PR TITLE
Phase 9: add v1 Species schema + strict validator and CI (species only)

### DIFF
--- a/.github/workflows/phase9-species.yml
+++ b/.github/workflows/phase9-species.yml
@@ -1,0 +1,41 @@
+﻿name: Phase 9 - Species (strict)
+
+on:
+  pull_request:
+    branches: [ master ]
+    paths:
+      - "schema/2024/v1/rules.species.schema.json"
+      - "scripts/validate_phase9_species.py"
+      - "scripts/_validation_common.py"
+      - "scripts/__init__.py"
+      - "rules/2024/species.json"
+      - ".github/workflows/phase9-species.yml"
+  push:
+    branches-ignore: [ master ]
+    paths:
+      - "schema/2024/v1/rules.species.schema.json"
+      - "scripts/validate_phase9_species.py"
+      - "scripts/_validation_common.py"
+      - "scripts/__init__.py"
+      - "rules/2024/species.json"
+      - ".github/workflows/phase9-species.yml"
+  workflow_dispatch:
+
+jobs:
+  validate-species:
+    name: Validate species (Phase 9 strict)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -VV
+          python -m pip install --upgrade pip jsonschema
+      - name: Run strict validator (module mode)
+        run: |
+          python -m scripts.validate_phase9_species

--- a/schema/2024/v1/rules.species.schema.json
+++ b/schema/2024/v1/rules.species.schema.json
@@ -1,0 +1,22 @@
+﻿{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "One D&D 2024 — Species (v1, conservative)",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": true,
+    "required": ["name", "source"],
+    "properties": {
+      "name":   { "type": "string", "minLength": 1 },
+      "source": { "type": "string", "pattern": "^X[A-Z]+$" },
+      "page":   { "type": ["integer", "string", "null"] },
+
+      "entries":   { "type": ["string", "array", "object"] },
+      "size":      { "type": ["string", "array", "object", "null"] },
+      "speed":     { "type": ["integer", "string", "array", "object", "null"] },
+      "languages": { "type": ["string", "array", "object", "null"] },
+      "traits":    { "type": ["string", "array", "object", "null"] },
+      "vision":    { "type": ["string", "array", "object", "null"] }
+    }
+  }
+}

--- a/scripts/validate_phase9_species.py
+++ b/scripts/validate_phase9_species.py
@@ -1,0 +1,10 @@
+﻿import sys
+from scripts._validation_common import run_standard_validation
+
+if __name__ == "__main__":
+    sys.exit(run_standard_validation(
+        category="species",
+        data_path="rules/2024/species.json",
+        schema_path="schema/2024/v1/rules.species.schema.json",
+        array_keys=["species", "race", "races"]
+    ))


### PR DESCRIPTION
## Phase 9 — Species: v1 schema, strict validator & CI

Extends Phase 9 to **Species** with a conservative v1 schema, a strict validator (module mode using `_validation_common.py`), and a dedicated CI workflow that fails on Species violations only. Other categories remain warn-only per the plan (“extend gradually, one category at a time”). See `schema_implementation_plan.docx`, Phase 9. 
