### PR TITLE
Phase 9: add v1 Class schema + strict validator and CI (class only)

### DIFF
--- a/.github/workflows/phase9-class.yml
+++ b/.github/workflows/phase9-class.yml
@@ -1,0 +1,38 @@
+﻿name: Phase 9 - Class (strict)
+
+on:
+  push:
+    paths:
+      - 'schema/2024/v1/rules.class.schema.json'
+      - 'scripts/validate_phase9_class.py'
+      - 'scripts/_validation_common.py'
+      - 'scripts/__init__.py'
+      - 'rules/2024/class.json'
+      - 'rules/2024/Class.json'
+      - '.github/workflows/phase9-class.yml'
+  pull_request:
+    paths:
+      - 'schema/2024/v1/rules.class.schema.json'
+      - 'scripts/validate_phase9_class.py'
+      - 'scripts/_validation_common.py'
+      - 'scripts/__init__.py'
+      - 'rules/2024/class.json'
+      - 'rules/2024/Class.json'
+      - '.github/workflows/phase9-class.yml'
+
+jobs:
+  validate-class:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip jsonschema
+      - name: Validate Class (Phase 9 strict)
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          python -m scripts.validate_phase9_class

--- a/schema/2024/v1/rules.class.schema.json
+++ b/schema/2024/v1/rules.class.schema.json
@@ -1,0 +1,36 @@
+﻿{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "One D&D 2024 — Class (v1)",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": true,
+    "required": ["name", "source"],
+    "properties": {
+      "name": { "type": "string", "minLength": 1 },
+      "source": { "type": "string", "pattern": "^X[A-Z]+$" },
+      "page": { "type": ["integer", "string", "null"] },
+
+      "shortName": { "type": "string" },
+      "hd": { "type": ["integer", "string", "object"] },
+      "classFeatures": { "type": ["array", "object", "string"] },
+      "subclassTitle": { "type": "string" },
+
+      "startingProficiencies": { "type": ["array", "object", "string"] },
+      "armorProficiencies": { "type": ["array", "object", "string"] },
+      "weaponProficiencies": { "type": ["array", "object", "string"] },
+      "toolProficiencies": { "type": ["array", "object", "string"] },
+      "savingThrows": { "type": ["array", "object", "string"] },
+      "skills": { "type": ["array", "object", "string"] },
+      "equipment": { "type": ["array", "object", "string"] },
+
+      "multiclassing": { "type": ["array", "object", "string"] },
+      "spellcasting": { "type": ["array", "object", "string"] },
+
+      "entries": { "type": ["string", "array", "object"] },
+      "prerequisite": { "type": ["string", "array", "object"] },
+      "level": { "type": ["integer", "string"] },
+      "otherSources": { "type": ["array", "object", "string"] }
+    }
+  }
+}

--- a/scripts/validate_phase9_class.py
+++ b/scripts/validate_phase9_class.py
@@ -1,0 +1,24 @@
+﻿import glob, sys
+from scripts._validation_common import run_standard_validation
+
+def _resolve_path():
+    candidates = [
+        "rules/2024/class.json",
+        "rules/2024/Class.json",
+        "rules/2024/*class*.json",
+    ]
+    for pat in candidates:
+        matches = sorted(glob.glob(pat))
+        if matches:
+            return matches[0]
+    print("ERROR: no data file resolved for category 'class' under rules/2024", flush=True)
+    sys.exit(2)
+
+if __name__ == "__main__":
+    resolved = _resolve_path()
+    run_standard_validation(
+        category="class",
+        data_path=resolved,
+        schema_path="schema/2024/v1/rules.class.schema.json",
+        array_keys=["class", "classes"]
+    )


### PR DESCRIPTION
Phase 9: Add v1 Class schema + strict validator and CI (Class only)

Summary
Implements the Phase 9 loop for Class: conservative v1 JSON Schema, strict module-friendly validator, and a dedicated CI workflow that fails on Class violations only while all other categories remain warn-only. This follows the per-category expansion approach defined in the Phase 9 plan.

Local Test
python -m scripts.validate_phase9_class
