### PR TITLE
Phase 9: add v1 Subclass schema + strict validator and CI (subclass o…

### DIFF
--- a/.github/workflows/phase9-subclass.yml
+++ b/.github/workflows/phase9-subclass.yml
@@ -1,0 +1,38 @@
+﻿name: Phase 9 - Subclass (strict)
+
+on:
+  push:
+    paths:
+      - 'schema/2024/v1/rules.subclass.schema.json'
+      - 'scripts/validate_phase9_subclass.py'
+      - 'scripts/_validation_common.py'
+      - 'scripts/__init__.py'
+      - 'rules/2024/subclass.json'
+      - 'rules/2024/Subclass.json'
+      - '.github/workflows/phase9-subclass.yml'
+  pull_request:
+    paths:
+      - 'schema/2024/v1/rules.subclass.schema.json'
+      - 'scripts/validate_phase9_subclass.py'
+      - 'scripts/_validation_common.py'
+      - 'scripts/__init__.py'
+      - 'rules/2024/subclass.json'
+      - 'rules/2024/Subclass.json'
+      - '.github/workflows/phase9-subclass.yml'
+
+jobs:
+  validate-subclass:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip jsonschema
+      - name: Validate Subclass (Phase 9 strict)
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          python -m scripts.validate_phase9_subclass

--- a/schema/2024/v1/rules.subclass.schema.json
+++ b/schema/2024/v1/rules.subclass.schema.json
@@ -1,0 +1,30 @@
+﻿{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "One D&D 2024 — Subclass (v1)",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": true,
+    "required": ["name", "source"],
+    "properties": {
+      "name": { "type": "string", "minLength": 1 },
+      "source": { "type": "string", "pattern": "^X[A-Z]+$" },
+      "page": { "type": ["integer", "string", "null"] },
+
+      "className": { "type": "string" },
+      "classSource": { "type": "string" },
+      "subclassShortName": { "type": "string" },
+      "subclassSource": { "type": "string" },
+
+      "entries": { "type": ["string", "array", "object"] },
+      "features": { "type": ["array", "object", "string"] },
+      "subclassFeatures": { "type": ["array", "object", "string"] },
+      "spellcasting": { "type": ["array", "object", "string"] },
+
+      "prerequisite": { "type": ["string", "array", "object"] },
+      "level": { "type": ["integer", "string"] },
+      "otherSources": { "type": ["array", "object", "string"] },
+      "fluff": { "type": ["array", "object", "string"] }
+    }
+  }
+}

--- a/scripts/validate_phase9_subclass.py
+++ b/scripts/validate_phase9_subclass.py
@@ -1,0 +1,24 @@
+﻿import glob, sys
+from scripts._validation_common import run_standard_validation
+
+def _resolve_path():
+    candidates = [
+        "rules/2024/subclass.json",
+        "rules/2024/Subclass.json",
+        "rules/2024/*subclass*.json",
+    ]
+    for pat in candidates:
+        matches = sorted(glob.glob(pat))
+        if matches:
+            return matches[0]
+    print("ERROR: no data file resolved for category 'subclass' under rules/2024", flush=True)
+    sys.exit(2)
+
+if __name__ == "__main__":
+    resolved = _resolve_path()
+    run_standard_validation(
+        category="subclass",
+        data_path=resolved,
+        schema_path="schema/2024/v1/rules.subclass.schema.json",
+        array_keys=["subclass", "subclasses"]
+    )


### PR DESCRIPTION
Phase 9: Add v1 Subclass schema + strict validator and CI (subclass only)

Summary
Extends the Phase 9 loop to Subclass: introduces a conservative v1 JSON Schema, a strict module-friendly validator, and a dedicated CI workflow that fails on Subclass violations only, keeping all other categories warn-only. This follows the per-category rollout defined in the Phase 9 plan (schema → strict local validator → strict CI).

What’s included

schema/2024/v1/rules.subclass.schema.json — Root array of objects; requires name (non-empty string) and source (pattern ^X[A-Z]+$); permissive typing for common fields (className, classSource, entries, features, subclassFeatures, spellcasting, etc.); "additionalProperties": true. This aligns with the plan’s conservative v1 guidance (identifiers only required; tolerate common 5etools shapes).
scripts/validate_phase9_subclass.py — Uses the shared helper (BOM-tolerant read, ASCII output), resolves common casings/globs under rules/2024/, and supports root array or known keys. Prints [OK] Phase 9: subclass validated cleanly (...) on success.

.github/workflows/phase9-subclass.yml — Runs in module mode with PYTHONPATH set; triggers on schema/validator/helper changes and both casings of the data path; fails the build on Subclass violations while others remain warn-only, as required by Phase 9.

Local Test
python -m scripts.validate_phase9_subclass
