### PR TITLE
Phase 9: add v1 Optional Feature schema + strict validator and CI (op…

### DIFF
--- a/.github/workflows/phase9-optionalfeature.yml
+++ b/.github/workflows/phase9-optionalfeature.yml
@@ -1,0 +1,44 @@
+﻿name: Phase 9 - Optional Feature (strict)
+
+on:
+  push:
+    paths:
+      - "schema/2024/v1/rules.optionalfeature.schema.json"
+      - "scripts/validate_phase9_optionalfeature.py"
+      - "scripts/_validation_common.py"
+      - "scripts/__init__.py"
+      - "rules/2024/optionalfeature.json"
+      - "rules/2024/OptionalFeature.json"
+      - "rules/2024/optionalFeature.json"
+      - "rules/2024/optionalfeatures.json"
+      - "rules/2024/*optional*feature*.json"
+      - ".github/workflows/phase9-optionalfeature.yml"
+  pull_request:
+    paths:
+      - "schema/2024/v1/rules.optionalfeature.schema.json"
+      - "scripts/validate_phase9_optionalfeature.py"
+      - "scripts/_validation_common.py"
+      - "scripts/__init__.py"
+      - "rules/2024/optionalfeature.json"
+      - "rules/2024/OptionalFeature.json"
+      - "rules/2024/optionalFeature.json"
+      - "rules/2024/optionalfeatures.json"
+      - "rules/2024/*optional*feature*.json"
+      - ".github/workflows/phase9-optionalfeature.yml"
+
+jobs:
+  validate-optionalfeature:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip jsonschema
+      - name: Validate Optional Feature (Phase 9 strict)
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          python -m scripts.validate_phase9_optionalfeature

--- a/schema/2024/v1/rules.optionalfeature.schema.json
+++ b/schema/2024/v1/rules.optionalfeature.schema.json
@@ -1,0 +1,30 @@
+﻿{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "One D&D 2024 — Optional Feature (v1)",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": true,
+    "required": ["name", "source"],
+    "properties": {
+      "name":   { "type": "string", "minLength": 1 },
+      "source": { "type": "string", "pattern": "^X[A-Z]+$" },
+      "page":   { "type": ["integer", "string", "null"] },
+
+      "type":            { "type": ["string", "array"] },
+      "featureType":     { "type": ["string", "array"] },
+      "className":       { "type": "string" },
+      "classSource":     { "type": "string" },
+      "subclassShortName": { "type": "string" },
+      "subclassSource":  { "type": "string" },
+
+      "entries":         { "type": ["string", "array", "object"] },
+      "effects":         { "type": ["string", "array", "object"] },
+      "prerequisite":    { "type": ["string", "array", "object"] },
+      "level":           { "type": ["integer", "string"] },
+      "otherSources":    { "type": ["array", "object", "string"] },
+      "tags":            { "type": ["string", "array"] },
+      "fluff":           { "type": ["array", "object", "string"] }
+    }
+  }
+}

--- a/scripts/_validation_common.py
+++ b/scripts/_validation_common.py
@@ -1,0 +1,58 @@
+﻿import json, sys
+from pathlib import Path
+from jsonschema import Draft202012Validator, validate
+
+def _print_ascii(msg: str) -> None:
+    try:
+        sys.stdout.write((msg.encode("ascii", "ignore").decode("ascii") + "\n"))
+        sys.stdout.flush()
+    except Exception:
+        print(msg, flush=True)
+
+def load_json(path: str):
+    with Path(path).open("r", encoding="utf-8-sig") as fh:
+        return json.load(fh)
+
+def load_schema(path: str):
+    with Path(path).open("r", encoding="utf-8-sig") as fh:
+        return json.load(fh)
+
+def _extract_array_payload(raw, array_keys):
+    if isinstance(raw, list):
+        return raw
+    if isinstance(raw, dict):
+        # Prefer explicitly-declared keys
+        for k in array_keys:
+            if k in raw and isinstance(raw[k], list):
+                return raw[k]
+        # Fallback: first list value found
+        for v in raw.values():
+            if isinstance(v, list):
+                return v
+    return None
+
+def run_standard_validation(category: str, data_path: str, schema_path: str, array_keys):
+    try:
+        raw = load_json(data_path)
+    except Exception as e:
+        _print_ascii(f"ERROR: failed to read JSON '{data_path}': {e}")
+        sys.exit(2)
+    try:
+        schema = load_schema(schema_path)
+    except Exception as e:
+        _print_ascii(f"ERROR: failed to read schema '{schema_path}': {e}")
+        sys.exit(2)
+
+    payload = _extract_array_payload(raw, array_keys)
+    if payload is None:
+        _print_ascii("ERROR: Expected a root array or an object with one of keys: " + ", ".join(array_keys))
+        sys.exit(1)
+
+    try:
+        Draft202012Validator.check_schema(schema)
+        validate(instance=payload, schema=schema)
+    except Exception as e:
+        _print_ascii(f"ERROR: schema validation failed: {e}")
+        sys.exit(1)
+
+    _print_ascii(f"[OK] Phase 9: {category} validated cleanly ({data_path})")

--- a/scripts/validate_phase9_optionalfeature.py
+++ b/scripts/validate_phase9_optionalfeature.py
@@ -1,0 +1,29 @@
+﻿import glob, sys
+from scripts._validation_common import run_standard_validation
+
+def _resolve_path():
+    candidates = [
+        "rules/2024/optionalfeature.json",
+        "rules/2024/OptionalFeature.json",
+        "rules/2024/optionalFeature.json",
+        "rules/2024/optionalfeatures.json",
+        "rules/2024/*optional*feature*.json",
+    ]
+    for pat in candidates:
+        matches = sorted(glob.glob(pat))
+        if matches:
+            return matches[0]
+    print("ERROR: no data file resolved for category 'optionalfeature' under rules/2024", flush=True)
+    sys.exit(2)
+
+if __name__ == "__main__":
+    resolved = _resolve_path()
+    run_standard_validation(
+        category="optionalfeature",
+        data_path=resolved,
+        schema_path="schema/2024/v1/rules.optionalfeature.schema.json",
+        array_keys=[
+            "optionalfeature", "optionalfeatures", "optionalFeatures",
+            "metamagic", "eldritchInvocation", "fightingStyle", "maneuver"
+        ]
+    )


### PR DESCRIPTION
Phase 9: Add v1 Optional Feature schema + strict validator and CI (optionalfeature only)

Summary
Implements the Phase 9 loop for Optional Feature: a conservative v1 JSON Schema, a strict module-friendly validator, and a dedicated CI job that fails on Optional Feature violations only while all other categories remain warn-only. This follows the per-category rollout defined in Phase 9 (repeat the schema → strict local validator → strict CI pattern).

What’s included

schema/2024/v1/rules.optionalfeature.schema.json — Root array of objects; requires only identifiers name (non-empty string) and source (2024 X* line); permissive typing for common fields (featureType, entries, prerequisite, etc.); "additionalProperties": true. This matches the plan’s conservative v1 approach (identifiers required; tolerate common 5etools shapes).

Local Test:

python -m scripts.validate_phase9_optionalfeature
