### PR TITLE
Phase 9: add v1 Status schema + strict validator and CI (status only)

### DIFF
--- a/.github/workflows/phase9-status.yml
+++ b/.github/workflows/phase9-status.yml
@@ -1,0 +1,38 @@
+﻿name: Phase 9 - Status (strict)
+
+on:
+  push:
+    paths:
+      - "schema/2024/v1/rules.status.schema.json"
+      - "scripts/validate_phase9_status.py"
+      - "scripts/_validation_common.py"
+      - "scripts/__init__.py"
+      - "rules/2024/status.json"
+      - "rules/2024/Status.json"
+      - ".github/workflows/phase9-status.yml"
+  pull_request:
+    paths:
+      - "schema/2024/v1/rules.status.schema.json"
+      - "scripts/validate_phase9_status.py"
+      - "scripts/_validation_common.py"
+      - "scripts/__init__.py"
+      - "rules/2024/status.json"
+      - "rules/2024/Status.json"
+      - ".github/workflows/phase9-status.yml"
+
+jobs:
+  validate-status:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip jsonschema
+      - name: Validate Status (Phase 9 strict)
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          python -m scripts.validate_phase9_status

--- a/schema/2024/v1/rules.status.schema.json
+++ b/schema/2024/v1/rules.status.schema.json
@@ -1,0 +1,21 @@
+﻿{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "One D&D 2024 — Status (v1)",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": true,
+    "required": ["name", "source"],
+    "properties": {
+      "name":   { "type": "string", "minLength": 1 },
+      "source": { "type": "string", "pattern": "^X[A-Z]+$" },
+      "page":   { "type": ["integer", "string", "null"] },
+
+      "entries":        { "type": ["string", "array", "object"] },
+      "tags":           { "type": ["string", "array"] },
+      "prerequisite":   { "type": ["string", "array", "object"] },
+      "otherSources":   { "type": ["array", "object", "string"] },
+      "fluff":          { "type": ["array", "object", "string"] }
+    }
+  }
+}

--- a/scripts/validate_phase9_status.py
+++ b/scripts/validate_phase9_status.py
@@ -1,0 +1,24 @@
+﻿import glob, sys
+from scripts._validation_common import run_standard_validation
+
+def _resolve_path():
+    candidates = [
+        "rules/2024/status.json",
+        "rules/2024/Status.json",
+        "rules/2024/*status*.json",
+    ]
+    for pat in candidates:
+        matches = sorted(glob.glob(pat))
+        if matches:
+            return matches[0]
+    print("ERROR: no data file resolved for category 'status' under rules/2024", flush=True)
+    sys.exit(2)
+
+if __name__ == "__main__":
+    resolved = _resolve_path()
+    run_standard_validation(
+        category="status",
+        data_path=resolved,
+        schema_path="schema/2024/v1/rules.status.schema.json",
+        array_keys=["status", "statuses"]
+    )


### PR DESCRIPTION
Extends the Phase 9 loop to Status: conservative v1 schema, strict module-friendly validator, and a dedicated CI job that fails on Status violations only, keeping all other categories warn-only. This is the exact per-category rollout described for Phase 9 (schema → strict local validator → strict CI).

What’s included

schema/2024/v1/rules.status.schema.json — Root array of objects; requires name (non-empty string) and source (pattern ^X[A-Z]+$); permissive typing for common narrative fields (entries, tags, prerequisite, etc.); "additionalProperties": true. Matches the conservative v1 guidance.

Local Test:
python -m scripts.validate_phase9_status
