### PR TITLE
Phase 9: add v1 BackgroundFluff schema + strict validator and CI (bac…

### DIFF
--- a/.github/workflows/phase9-backgroundfluff.yml
+++ b/.github/workflows/phase9-backgroundfluff.yml
@@ -1,0 +1,40 @@
+name: Phase 9 - Background Fluff (strict)
+
+on:
+  push:
+    paths:
+      - 'schema/2024/v1/rules.backgroundfluff.schema.json'
+      - 'scripts/validate_phase9_backgroundfluff.py'
+      - 'scripts/_validation_common.py'
+      - 'scripts/__init__.py'
+      - 'rules/2024/backgroundFluff.json'
+      - 'rules/2024/BackgroundFluff.json'
+      - '.github/workflows/phase9-backgroundfluff.yml'
+      - 'rules/2024/*backgroundfluff*.json'
+  pull_request:
+    paths:
+      - 'schema/2024/v1/rules.backgroundfluff.schema.json'
+      - 'scripts/validate_phase9_backgroundfluff.py'
+      - 'scripts/_validation_common.py'
+      - 'scripts/__init__.py'
+      - 'rules/2024/backgroundFluff.json'
+      - 'rules/2024/BackgroundFluff.json'
+      - '.github/workflows/phase9-backgroundfluff.yml'
+      - 'rules/2024/*backgroundfluff*.json'
+
+jobs:
+  validate-backgroundfluff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip jsonschema
+      - name: Validate Background Fluff (Phase 9 strict)
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          python -m scripts.validate_phase9_backgroundfluff

--- a/schema/2024/v1/rules.backgroundfluff.schema.json
+++ b/schema/2024/v1/rules.backgroundfluff.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "One D&D 2024 — Background Fluff (v1)",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": true,
+    "required": ["name", "source"],
+    "properties": {
+      "name":   { "type": "string", "minLength": 1 },
+      "source": { "type": "string", "pattern": "^X[A-Z]+$" },
+      "page":   { "type": ["integer", "string", "null"] },
+      "entries":        { "type": ["string", "array", "object"] },
+      "prerequisite":   { "type": ["string", "array", "object"] },
+      "tags":           { "type": ["string", "array"] },
+      "otherSources":   { "type": ["array", "object", "string"] },
+      "fluff":          { "type": ["array", "object", "string"] }
+    }
+  }
+}

--- a/scripts/validate_phase9_backgroundfluff.py
+++ b/scripts/validate_phase9_backgroundfluff.py
@@ -1,0 +1,24 @@
+import glob, sys
+from scripts._validation_common import run_standard_validation
+
+def _resolve_path():
+    candidates = [
+        "rules/2024/backgroundFluff.json",
+        "rules/2024/BackgroundFluff.json",
+        "rules/2024/*backgroundfluff*.json",
+    ]
+    for pat in candidates:
+        matches = sorted(glob.glob(pat))
+        if matches:
+            return matches[0]
+    print("ERROR: no data file resolved for category 'backgroundFluff' under rules/2024", flush=True)
+    sys.exit(2)
+
+if __name__ == "__main__":
+    resolved = _resolve_path()
+    run_standard_validation(
+        category="backgroundFluff",
+        data_path=resolved,
+        schema_path="schema/2024/v1/rules.backgroundfluff.schema.json",
+        array_keys=['backgroundFluff', 'backgroundFluffs', 'backgroundFluffes']
+    )


### PR DESCRIPTION
Phase 9: Add v1 BackgroundFluff schema + strict validator and CI (backgroundfluff only)

Summary
Implements the Phase 9 loop for BackgroundFluff: conservative v1 JSON Schema, a strict module-friendly validator, and a dedicated CI workflow that fails on BackgroundFluff violations only, keeping other categories warn-only. This follows the per-category rollout in the plan (schema → strict local validator → strict CI).

What’s included

schema/2024/v1/rules.backgroundfluff.schema.json — Root array of objects; requires only identifiers name (non-empty string) and source (pattern ^X[A-Z]+$ for 2024 X* books); permissive typing for narrative fields (entries, tags, prerequisite, etc.); "additionalProperties": true. This matches the plan’s conservative v1 guidance.…kgroundfluff only)

Local test:

python -m scripts.validate_phase9_backgroundfluff
