### PR TITLE
Phase 9: add v1 FeatFluff schema + strict validator and CI (featfluff…

### DIFF
--- a/.github/workflows/phase9-featfluff.yml
+++ b/.github/workflows/phase9-featfluff.yml
@@ -1,0 +1,40 @@
+name: Phase 9 - Feat Fluff (strict)
+
+on:
+  push:
+    paths:
+      - 'schema/2024/v1/rules.featfluff.schema.json'
+      - 'scripts/validate_phase9_featfluff.py'
+      - 'scripts/_validation_common.py'
+      - 'scripts/__init__.py'
+      - 'rules/2024/featFluff.json'
+      - 'rules/2024/FeatFluff.json'
+      - '.github/workflows/phase9-featfluff.yml'
+      - 'rules/2024/*featfluff*.json'
+  pull_request:
+    paths:
+      - 'schema/2024/v1/rules.featfluff.schema.json'
+      - 'scripts/validate_phase9_featfluff.py'
+      - 'scripts/_validation_common.py'
+      - 'scripts/__init__.py'
+      - 'rules/2024/featFluff.json'
+      - 'rules/2024/FeatFluff.json'
+      - '.github/workflows/phase9-featfluff.yml'
+      - 'rules/2024/*featfluff*.json'
+
+jobs:
+  validate-featfluff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip jsonschema
+      - name: Validate Feat Fluff (Phase 9 strict)
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          python -m scripts.validate_phase9_featfluff

--- a/schema/2024/v1/rules.featfluff.schema.json
+++ b/schema/2024/v1/rules.featfluff.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "One D&D 2024 — Feat Fluff (v1)",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": true,
+    "required": ["name", "source"],
+    "properties": {
+      "name":   { "type": "string", "minLength": 1 },
+      "source": { "type": "string", "pattern": "^X[A-Z]+$" },
+      "page":   { "type": ["integer", "string", "null"] },
+      "entries":        { "type": ["string", "array", "object"] },
+      "prerequisite":   { "type": ["string", "array", "object"] },
+      "tags":           { "type": ["string", "array"] },
+      "otherSources":   { "type": ["array", "object", "string"] },
+      "fluff":          { "type": ["array", "object", "string"] }
+    }
+  }
+}

--- a/scripts/validate_phase9_featfluff.py
+++ b/scripts/validate_phase9_featfluff.py
@@ -1,0 +1,24 @@
+import glob, sys
+from scripts._validation_common import run_standard_validation
+
+def _resolve_path():
+    candidates = [
+        "rules/2024/featFluff.json",
+        "rules/2024/FeatFluff.json",
+        "rules/2024/*featfluff*.json",
+    ]
+    for pat in candidates:
+        matches = sorted(glob.glob(pat))
+        if matches:
+            return matches[0]
+    print("ERROR: no data file resolved for category 'featFluff' under rules/2024", flush=True)
+    sys.exit(2)
+
+if __name__ == "__main__":
+    resolved = _resolve_path()
+    run_standard_validation(
+        category="featFluff",
+        data_path=resolved,
+        schema_path="schema/2024/v1/rules.featfluff.schema.json",
+        array_keys=['featFluff', 'featFluffs', 'featFluffes']
+    )


### PR DESCRIPTION
PR_DESCRIPTION = """
Title: Phase 9: Add v1 FeatFluff schema + strict validator and CI (featfluff only)

Summary
Adds a conservative v1 JSON Schema for FeatFluff, a strict module-friendly validator, and a dedicated CI workflow that fails on FeatFluff violations only, while other categories remain warn-only.

What’s included
- schema/2024/v1/rules.featfluff.schema.json — Root array of objects; requires `name` (non-empty string) and `source` (pattern `^X[A-Z]+$`); permissive typing for narrative fields (e.g., `entries`, `tags`, `fluff`); `"additionalProperties": true`.
- scripts/validate_phase9_featfluff.py — Uses the shared helper (BOM-tolerant reads, ASCII-only prints), resolves common casings/globs under `rules/2024/`, supports root array or known keys, and prints `[OK] Phase 9: featfluff validated cleanly (...)` on success.
- .github/workflows/phase9-featfluff.yml — Runs in module mode with `PYTHONPATH` set; triggers on this category’s schema/validator/helper and FeatFluff data paths; CI fails the build only for this category.

Local test
python -m scripts.validate_phase9_featfluff

Acceptance criteria
- Schema follows the conservative v1 rules for FeatFluff (array root; identifiers required; permissive optional fields; additionalProperties allowed).
- Local strict validator prints `[OK]` for FeatFluff.
- CI enforces FeatFluff strictly (red on violation); other categories remain warn-only.
- PR merged; feature branch deleted; master synced.
"""
